### PR TITLE
One user item endpoint

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -9,6 +9,10 @@ class Api::V1::ItemsController < ApplicationController
       render json: { errors: item.errors }, status: 400
     end
   end
+  
+  def show
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
 
   private 
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do 
       resources :users, only: [:show] do
         get '/items/find_all', to: 'items/search#show'
-        resources :items, only: [:create]
+        resources :items, only: [:show, :create]
       end
     end
   end

--- a/spec/requests/api/v1/items/show_request_spec.rb
+++ b/spec/requests/api/v1/items/show_request_spec.rb
@@ -53,6 +53,7 @@ describe 'GET /users/:user_id/items/:item_id' do
       # expect(item_data[:notes]).to be_a(String)
     end
   end
+  
   context 'the item does not exist' do
     it 'returns an error message' do
       user = create(:user)

--- a/spec/requests/api/v1/items/show_request_spec.rb
+++ b/spec/requests/api/v1/items/show_request_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe 'GET /users/:user_id/items/:item_id' do
+  context 'if a user exists' do
+    it 'returns one item by ID' do
+      user = create(:user)
+      blob = ActiveStorage::Blob.create_after_upload!(
+                                                        io: File.open('src/assets/test_image.png'),
+                                                        filename: 'test_image.png',
+                                                        content_type: 'image/png'
+                                                      )
+      item1 = Item.create!(user_id: user.id, season: "spring", clothing_type: "tops", size: "L", color: "red")
+      item2 = Item.create!(user_id: user.id, season: "summer", clothing_type: "shoes", size: "L", color: "black")
+
+      Item.all.each do |item|
+        item.image.attach(blob)
+      end
+      
+      get "/api/v1/users/#{user.id}/items/#{item1.id}"
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      expect(item_response).to have_key(:data)
+      expect(item_response[:data]).to be_a(Hash)
+      
+      expect(item_response[:data]).to have_key(:id)
+      expect(item_response[:data][:id]).to be_a(String)
+
+      expect(item_response[:data]).to have_key(:type)
+      expect(item_response[:data][:type]).to be_a(String)
+
+      expect(item_response[:data]).to have_key(:attributes)
+      expect(item_response[:data][:attributes]).to be_a(Hash)
+
+      item_data = item_response[:data][:attributes]
+      
+      expect(item_data).to have_key(:season)
+      expect(item_data[:season]).to be_a(String)
+
+      expect(item_data).to have_key(:clothing_type)
+      expect(item_data[:clothing_type]).to be_a(String)
+
+      expect(item_data).to have_key(:size)
+      # expect(item_data[:size]).to be_a(String)
+
+      expect(item_data).to have_key(:image_url)
+      expect(item_data[:image_url]).to be_a(String)
+
+      expect(item_data).to have_key(:notes)
+      # expect(item_data[:notes]).to be_a(String)
+    end
+  end
+end


### PR DESCRIPTION
Issue #10 

# Summary of things changed:
- Added happy and sad path testing to GET one item based off item ID.

# List any known issues (include relevant code snippets):
- If an item is not created correctly on Postman (i.e. the user has to upload an image from THEIR computer - and cannot utilize the mocked image), then the item will still be created but the endpoint will fail. This will likely be a sad path that needs to be addressed for creating an Item. 

# Necessary checkmarks: 
(replace space between brackets with 'x' to check box)

- [x]  All tests are passing
- [x]  Code will run locally
- [x]  Confirm self-review

# Json response snippet:
```json
{
    "data": {
        "id": "2",
        "type": "item",
        "attributes": {
            "user_id": 1,
            "season": "spring",
            "clothing_type": "accessories",
            "color": "black",
            "size": "7",
            "image_url": "http://localhost:5000/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--d6ccc60a3340043d8b0ed6ddf45f9e3cce821ca5/Screen%20Shot%202023-03-03%20at%2010.09.26.png",
            "notes": "brand new in box"
        }
    }
}
```