### PR TITLE
Items endpoint refactor

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,7 +4,11 @@ class Api::V1::ItemsController < ApplicationController
     user = User.find(params[:user_id])
     item = Item.create(item_params)
 
-    render json: ItemSerializer.new(item), status: 201
+    if item.save
+      render json: ItemSerializer.new(item), status: 201
+    else
+      render json: { "message": "Please ensure no empty strings are passed in." }, status: 400
+    end
   end
   
   def show

--- a/spec/requests/api/v1/items/find_all_request_spec.rb
+++ b/spec/requests/api/v1/items/find_all_request_spec.rb
@@ -140,4 +140,61 @@ describe 'GET /users/:id/items/find_all?' do
       expect(items_response[:data].count).to eq(0)
     end
   end
+
+  context 'if empty strings are passed in the query' do
+    it 'ignore that filter and return items that match any other filter' do
+      user = create(:user)
+      blob = ActiveStorage::Blob.create_after_upload!(
+                                                      io: File.open('src/assets/test_image.png'),
+                                                      filename: 'test_image.png',
+                                                      content_type: 'image/png'
+                                                      )
+      item1 = Item.create!(user_id: user.id, season: "spring", clothing_type: "tops", size: "L", color: "red")
+      item2 = Item.create!(user_id: user.id, season: "fall", clothing_type: "bottoms", size: "L", color: "black")
+      item3 = Item.create!(user_id: user.id, season: "fall", clothing_type: "bottoms", size: "L", color: "blue")
+      Item.all.each do |item|
+        item.image.attach(blob)
+      end
+
+      get "/api/v1/users/#{user.id}/items/find_all?season=&color=red"
+
+      items_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      expect(items_response).to have_key(:data)
+      expect(items_response[:data]).to be_a(Array)
+
+      expect(items_response[:data][0]).to have_key(:id)
+      expect(items_response[:data][0][:id]).to be_a(String)
+
+      expect(items_response[:data][0]).to have_key(:type)
+      expect(items_response[:data][0][:type]).to be_a(String)
+
+      expect(items_response[:data][0]).to have_key(:attributes)
+      expect(items_response[:data][0][:attributes]).to be_a(Hash)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:user_id)
+      expect(items_response[:data][0][:attributes][:user_id]).to be_a(Integer)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:season)
+      expect(items_response[:data][0][:attributes][:season]).to be_a(String)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:clothing_type)
+      expect(items_response[:data][0][:attributes][:clothing_type]).to be_a(String)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:color)
+      expect(items_response[:data][0][:attributes][:color]).to be_a(String)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:size)
+      expect(items_response[:data][0][:attributes][:size]).to be_a(String)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:image_url)
+      expect(items_response[:data][0][:attributes][:image_url]).to be_a(String)
+
+      expect(items_response[:data][0][:attributes]).to have_key(:notes)
+      expect(items_response[:data][0][:attributes][:notes]).to eq(nil)
+    end
+  end
 end

--- a/spec/requests/api/v1/items/new_request_spec.rb
+++ b/spec/requests/api/v1/items/new_request_spec.rb
@@ -95,4 +95,36 @@ describe 'POST /users/:id/items' do
       expect(item_response[:error][0][:status]).to be_a(String)
     end
   end
+
+  describe 'if empty strings are passed in' do
+    it 'returns an error message' do
+
+      user = create(:user)
+
+      headers = { "CONTENT_TYPE": "application/json"}
+      item_params = {
+                      "user_id": user.id,
+                      "season": "",
+                      "clothing_type": "shoes",
+                      "color": "black",
+                      "size": "7",
+                      "image": nil,
+                      "notes": "testing header"
+                    }
+
+      expect(Item.count).to eq(0)
+
+      post "/api/v1/users/#{user.id}/items", headers: headers, params: JSON.generate(item_params)
+
+      item_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(Item.count).to eq(0)
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      expect(item_response).to have_key(:message)
+      expect(item_response[:message]).to be_a(String)
+      expect(item_response[:message]).to eq("Please ensure no empty strings are passed in.")
+    end
+  end
 end


### PR DESCRIPTION
Issue #50  

# Summary of things changed:
- Adds a test for items query endpoint for empty strings
- Adds sad path test item creation when empty strings are passed in
# List any known issues (include relevant code snippets):

# Necessary checkmarks: 
(replace space between brackets with 'x' to check box)

- [x]  All tests are passing
- [x]  Code will run locally
- [x]  Confirm self-review

# Json response snippet:
``` json
{ 
     "message": "Please ensure no empty strings are passed in."
}
```