### PR TITLE
Update the event index endpoint to include events with one or more items

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::EventsController < ApplicationController
   def index
-    events = Event.all
+    events = Event.all_events_with_items
     render json: EventSerializer.new(events)
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,4 +4,11 @@ class Event < ApplicationRecord
 
   validates_presence_of :outfit_date
   validates_uniqueness_of :outfit_date
+
+  def self.all_events_with_items
+    self.joins(:event_items)
+    .group(:id)
+    .having('count(event_items.id) >= 1')
+    .order(:id)
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,4 +10,21 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:outfit_date) }
     it { should validate_uniqueness_of(:outfit_date) }
   end
+
+  describe 'class methods' do
+    describe '#find_all_events_with_items' do
+      it 'returns all events that have items' do
+        user = create(:user)
+        item1 = Item.create(user_id: user.id, clothing_type: "tops")
+        event1 = Event.create!(outfit_date: Date.today)
+        event2 = Event.create!(outfit_date: Date.today+1.day)
+        event3 = Event.create!(outfit_date: Date.today+2.day)
+        event_item1 = EventItem.create!(event_id: event1.id, item_id: item1.id)
+        event_item2 = EventItem.create!(event_id: event2.id, item_id: item1.id)
+
+        expect(Event.all_events_with_items).to eq([event1, event2])
+        expect(Event.all_events_with_items).to_not include([event3])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Issue #77 

# Summary of things changed:
- Updates the event index request to only include events with one or more event items
# List any known issues (include relevant code snippets):
- n/a
# Necessary checkmarks: 
(replace space between brackets with 'x' to check box)

- [x]  All tests are passing
- [x]  Code will run locally
- [x]  Confirm self-review

# Json response snippet:
```json
{
    "data": [
        {
            "id": "3",
            "type": "event",
            "attributes": {
                "outfit_date": "2023-05-01"
            }
        },
        {
            "id": "4",
            "type": "event",
            "attributes": {
                "outfit_date": "2023-05-13"
            }
        },
        {
            "id": "5",
            "type": "event",
            "attributes": {
                "outfit_date": "2023-05-23"
            }
        }
    ]
}
```